### PR TITLE
Fix `unomi` image not found.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - "9200:9200"
 
   unomi:
-    image: unomi
+    image: mikeghen/unomi:1.3
     container_name: unomi
     environment:
       - ELASTICSEARCH_HOST=elasticsearch


### PR DESCRIPTION
### WHY

```
ERROR: The image for the service you're trying to recreate has been removed. If you continue, volume data could be lost. Consider backing up your data before continuing.
```

### WHAT
* Use image of `https://hub.docker.com/r/mikeghen/unomi`